### PR TITLE
use getopts not getopt

### DIFF
--- a/install-ngxblocker
+++ b/install-ngxblocker
@@ -39,22 +39,36 @@ REPO=https://raw.githubusercontent.com/mitchellkrogza/nginx-ultimate-bad-bot-blo
 ####### end user configuration ##########################
 
 usage() {
-	local script=$(basename $0)
-	cat <<EOF
-$script: download Nginx Bad Bot Blocker configuration to: [ $CONF_DIR ] [ $BOTS_DIR ]
+        local script=$(basename $0)
+        cat <<EOF
+$script: INSTALL Nginx Bad Bot Blocker configuration to: [ $CONF_DIR ] [ $BOTS_DIR ]
 
 Usage: $script [OPTIONS]
-        [ -b | --bots  ] : Bot rules directory           (default: $BOTS_DIR)
-        [ -c | --conf  ] : NGINX conf directory          (default: $CONF_DIR)
-        [ -r | --repo  ] : Change repo url	         (default: $REPO)
-        [ -x | --exec  ] : Actually change the files     (default: don't change anything)
-        [ -h | --help  ] : this help message
+        [ -b ] : Bot rules directory           (default: $BOTS_DIR)
+        [ -c ] : NGINX conf directory          (default: $CONF_DIR)
+        [ -r ] : Change repo url               (default: $REPO)
+        [ -x ] : Actually change the files     (default: don't change anything)
+        [ -v ] : Print blacklist version
+        [ -h ] : this help message
 
 Examples:
  $script       (Don't change anything: display results on stdout)
  $script -x    (Download / update config files)
 EOF
-	return 0
+        exit 0
+}
+
+check_version() {
+        local file=$CONF_DIR/globalblacklist.conf
+
+        if [ -f $file ]; then
+                grep Version $file
+                grep 'Updated:' $file
+        else
+                printf "Missing '$file' (pass -c \$path before -v)\n"
+        fi
+
+        exit 0
 }
 
 longest_str() {
@@ -127,27 +141,58 @@ check_config() {
 	done
 }
 
+sanitize_path() {
+        echo $1 |tr -cd '[:alnum:] [=@=] [=.=] [=-=] [=/=] [=_=]' \
+                |tr -s '@.-/_' |awk '{print tolower($0)}'
+}
+
+sanitize_url() {
+        echo $1 |tr -cd '[:alnum:] [=:=] [=.=] [=-=] [=/=]' \
+                |tr -s ':.-' |awk '{print tolower($0)}'
+}
+
+check_args() {
+        local option=$1 type=$2 arg=$3
+        local msg="ERROR: option '-$option' argument '$arg' requires:"
+
+        case "$type" in
+                path)   if ! echo $arg | grep ^/ 1>/dev/null; then
+                                printf "$msg absolute path.\n"
+                                exit 1
+                        fi
+                        ;;
+                url)    if ! echo $arg | grep -E ^http[s]?://[0-9a-zA-Z-]+[.]+[/0-9a-zA-Z.]+ 1>/dev/null; then
+                                printf "$msg url => http[s]://the.url\n"
+                                exit 1
+                        fi
+                        ;;
+                none)   printf "$msg argument.\n"; exit 1;;
+        esac
+}
+
 get_options() {
-	local options=$(getopt -o b:c:r:hx --long \
-		bots:,conf:,repo:,help,exec -- "$@" 2>/dev/null)
+        local arg= opts=
 
-	if [ $? -ne 0 ]; then
-		usage
-		exit 1
-	fi
+        while getopts :b:c:r:xvh opts "$@"
+        do
+                if [ -n "${OPTARG}" ]; then
+                        case "$opts" in
+                                r) arg=$(sanitize_url ${OPTARG});;
+                                *) arg=$(sanitize_path ${OPTARG});;
+                        esac
+                fi
 
-	eval set -- "$options"
-
-	while :; do
-		case "$1" in
-		-h | --help) usage && exit 1;;
-		-x | --exec) DRY_RUN=N; shift;;
-		-b | --bots) BOTS_DIR=$2; shift 2;;
-		-c | --conf) CONF_DIR=$2; shift 2;;
-		-r | --repo) REPO=$2; shift 2;;
-		*) break;;
-		esac
-	done
+                case "$opts" in
+                        b) BOTS_DIR=$arg; check_args $opts path $arg ;;
+                        c) CONF_DIR=$arg; check_args $opts path $arg ;;
+                        r) REPO=$arg; check_args $opts url $arg ;;
+                        x) DRY_RUN=N ;;
+                        v) check_version ;;
+                        h) usage ;;
+                       \?) usage ;;
+                        :) check_args $OPTARG none none ;;
+                esac
+        done
 }
 
 wget_opts() {

--- a/setup-ngxblocker
+++ b/setup-ngxblocker
@@ -22,21 +22,21 @@ INC_DDOS="Y"
 ####### end user configuration ###########################
 
 usage() {
-	local script=$(basename $0)
-	cat <<EOF
-$script: add Nginx Bad Bot Blocker configuration [ in $MAIN_CONF ] [ $VHOST_DIR/* ]
+        local script=$(basename $0)
+        cat <<EOF
+$script: SETUP Nginx Bad Bot Blocker configuration in [ $MAIN_CONF ] [ $VHOST_DIR/* ]
 
 Usage: $script [OPTIONS]
-	[ -w | --www   ] : WWW path                      (default: $WWW)
-	[ -e | --ext   ] : Vhost file extension          (default: .$VHOST_EXT)
-	[ -v | --vhost ] : Vhost directory               (default: $VHOST_DIR)
-	[ -b | --bots  ] : Bot rules directory           (default: $BOTS_DIR)
-	[ -c | --conf  ] : NGINX conf directory          (default: $CONF_DIR)
-	[ -m | --main  ] : NGINX main configuration      (default: $MAIN_CONF)
-	[ -n | --names ] : NO whitelist of .names only   (default: $DOT_NAMES)
-	[ -d | --ddos  ] : NO insert of DDOS rule        (default: $INC_DDOS)
-	[ -x | --exec  ] : Actually change the files     (default: don't change anything)
-	[ -h | --help  ] : this help message
+        [ -w ] : WWW path                      (default: $WWW)
+        [ -e ] : Vhost file extension          (default: .$VHOST_EXT)
+        [ -v ] : Vhost directory               (default: $VHOST_DIR)
+        [ -b ] : Bot rules directory           (default: $BOTS_DIR)
+        [ -c ] : NGINX conf directory          (default: $CONF_DIR)
+        [ -m ] : NGINX main configuration      (default: $MAIN_CONF)
+        [ -n ] : NO whitelist of .names only   (default: $DOT_NAMES)
+        [ -d ] : NO insert of DDOS rule        (default: $INC_DDOS)
+        [ -x ] : Actually change the files     (default: don't change anything)
+        [ -h ] : this help message
 
 Examples:
  $script -n    (Whitelist all directory names in $WWW as domains: not just dot.name directories)
@@ -44,7 +44,7 @@ Examples:
  $script       (Don't change anything: display results on stdout)
  $script -x    (Change / update config files)
 EOF
-	return 0
+        exit 0
 }
 
 check_config() {
@@ -184,30 +184,54 @@ find_includes() {
 	echo $line
 }
 
+sanitize_path() {
+        echo $1 |tr -cd '[:alnum:] [=@=] [=.=] [=-=] [=/=] [=_=]' \
+                |tr -s '@.-/_' |awk '{print tolower($0)}'
+}
+
+sanitize_ext() {
+        echo $1 |tr -cd '[:alnum:]' |awk '{print tolower($0)}'
+}
+
+check_args() {
+        local option=$1 type=$2 arg=$3
+        local msg="ERROR: option '-$option' argument '$arg' requires:"
+
+        case "$type" in
+                path)   if ! echo $arg | grep ^/ 1>/dev/null; then
+                                printf "$msg absolute path.\n"
+                                exit 1
+                        fi
+                        ;;
+                none)   printf "$msg argument.\n"; exit 1;;
+        esac
+}
+
 get_options() {
-	local options=$(getopt -o w:e:v:b:c:m:ndhx --long \
-		www:,ext:,vhost:,bots:,conf:,main:,names,ddos,help,exec -- "$@" 2>/dev/null)
+        local arg= opts=
 
-        if [ $? -ne 0 ]; then
-                usage
-                exit 1
-        fi
+        while getopts :w:e:v:b:c:m:ndxh opts "$@"
+        do
+                if [ -n "${OPTARG}" ]; then
+                        case "$opts" in
+                                e) arg=$(sanitize_ext ${OPTARG});;
+                                *) arg=$(sanitize_path ${OPTARG});;
+                        esac
+                fi
 
-	eval set -- "$options"
-
-        while :; do
-                case "$1" in
-                -h | --help) usage && exit 1;;
-                -x | --exec) DRY_RUN=N; shift;;
-                -w | --www) WWW=$2; shift 2;;
-                -e | --ext) VHOST_EXT=$2; shift 2;;
-                -v | --vhost) VHOST_DIR=$2; shift 2;;
-                -b | --bots) BOTS_DIR=$2; shift 2;;
-                -c | --conf) CONF_DIR=$2; shift 2;;
-                -m | --main) MAIN_CONF=$2; shift 2;;
-                -n | --names) DOT_NAMES=N; shift;;
-                -d | --ddos) INC_DDOS=N; shift;;
-                *) break;;
+                case "$opts" in
+                        w) WWW=$arg; check_args $opts path $arg ;;
+                        e) VHOST_EXT=$arg;;
+                        v) VHOST_DIR=$arg; check_args $opts path $arg ;;
+                        b) BOTS_DIR=$arg; check_args $opts path $arg ;;
+                        c) CONF_DIR=$arg; check_args $opts path $arg ;;
+                        m) MAIN_CONF=$arg; check_args $opts path $arg ;;
+                        n) DOT_NAMES=N ;;
+                        d) INC_DDOS=N ;;
+                        x) DRY_RUN=N ;;
+                        h) usage ;;
+                       \?) usage ;;
+                        :) check_args $OPTARG none none ;;
                 esac
         done
 }

--- a/update-ngxblocker
+++ b/update-ngxblocker
@@ -35,22 +35,36 @@ CONF_DIR=/etc/nginx/conf.d
 ##### end user configuration ##############################################################
 
 usage() {
-	local script=$(basename $0)
-	cat <<EOF
-$script: update Nginx Bad Bot Blocker blacklist to: [ $CONF_DIR ]
+        local script=$(basename $0)
+        cat <<EOF
+$script: UPDATE Nginx Bad Bot Blocker blacklist in: [ $CONF_DIR ]
 
 Usage: $script [OPTIONS]
-	[ -c | --conf     ] : NGINX conf directory          (default: $CONF_DIR)
-	[ -r | --repo     ] : Change repo url               (default: $REPO)
-	[ -e | --email    ] : Change email address          (default: $EMAIL)
-	[ -n | --no-email ] : Do not send email report      (default: $SEND_EMAIL)
-	[ -h | --help     ] : this help message
+        [ -c ] : NGINX conf directory          (default: $CONF_DIR)
+        [ -r ] : Change repo url               (default: $REPO)
+        [ -e ] : Change email address          (default: $EMAIL)
+        [ -n ] : Do not send email report      (default: $SEND_EMAIL)
+        [ -v ] : Print blacklist version
+        [ -h ] : this help message
 
 Examples:
- $script		         (Download blacklist.conf to: $CONF_DIR)
+ $script                         (Download blacklist.conf to: $CONF_DIR)
  $script -c /my/custom/conf.d    (Download blacklist.conf to a custom location)
 EOF
-	return 0
+        exit 0
+}
+
+check_version() {
+        local file=$CONF_DIR/globalblacklist.conf
+
+        if [ -f $file ]; then
+                grep Version $file
+                grep 'Updated:' $file
+        else
+                printf "Missing '$file' (pass -c \$path before -v)\n"
+        fi
+
+        exit 0
 }
 
 service_cmd() {
@@ -77,28 +91,69 @@ wget_opts() {
 	echo $opts
 }
 
+sanitize_path() {
+        echo $1 |tr -cd '[:alnum:] [=@=] [=.=] [=-=] [=/=] [=_=]' \
+                |tr -s '@.-/_' |awk '{print tolower($0)}'
+}
+
+sanitize_url() {
+        echo $1 |tr -cd '[:alnum:] [=:=] [=.=] [=-=] [=/=]' \
+                |tr -s ':.-' |awk '{print tolower($0)}'
+}
+
+sanitize_email() {
+        echo $1 |tr -cd '[:alnum:] [=@=] [=.=] [=-=] [=_=]' \
+                |tr -s '@-_.' |awk '{print tolower($0)}'
+}
+
+check_args() {
+        local option=$1 type=$2 arg=$3
+        local msg="ERROR: option '-$option' argument '$arg' requires:"
+
+        case "$type" in
+                path)   if ! echo $arg | grep ^/ 1>/dev/null; then
+                                printf "$msg absolute path.\n"
+                                exit 1
+                        fi
+                        ;;
+                email)  if ! echo $arg | grep -E ^[-_[:alnum:]]+@[-_[:alnum:]]+[\.][\.a-z]+ 1>/dev/null; then
+                                printf "$msg email@domain.com\n"
+                                exit 1
+                        fi
+                        ;;
+                url)    if ! echo $arg | grep -E ^http[s]?://[0-9a-zA-Z-]+[.]+[/0-9a-zA-Z.]+ 1>/dev/null; then
+                                printf "$msg url => http[s]://the.url\n"
+                                exit 1
+                        fi
+                        ;;
+                none)   printf "$msg argument.\n"; exit 1;;
+        esac
+}
 
 get_options() {
-	local options=$(getopt -o c:r:e:nh --long \
-		bots:,conf:,repo:,email:,no-email,help,exec -- "$@" 2>/dev/null)
+        local arg= opts=
 
-	if [ $? -ne 0 ]; then
-		usage
-		exit 1
-	fi
+        while getopts :c:r:e:nvh opts "$@"
+        do
+                if [ -n "${OPTARG}" ]; then
+                        case "$opts" in
+                                r) arg=$(sanitize_url ${OPTARG});;
+                                e) arg=$(sanitize_email ${OPTARG});;
+                                *) arg=$(sanitize_path ${OPTARG});;
+                        esac
+                fi
 
-	eval set -- "$options"
-
-	while :; do
-		case "$1" in
-		-h | --help) usage && exit 1;;
-		-c | --conf) CONF_DIR=$2; shift 2;;
-		-r | --repo) REPO=$2; shift 2;;
-		-e | --email) EMAIL=$2; shift 2;;
-		-n | --no-email) SEND_EMAIL=N; shift 2;;
-		*) break;;
-		esac
-	done
+                case "$opts" in
+                        c) CONF_DIR=$arg; check_args $opts path $arg ;;
+                        r) REPO=$arg; check_args $opts url $arg ;;
+                        e) EMAIL=$arg; check_args $opts email $arg ;;
+                        n) SEND_EMAIL=N ;;
+                        v) check_version ;;
+                        h) usage ;;
+                       \?) usage ;;
+                        :) check_args $OPTARG none none ;;
+                esac
+        done
 }
 
 main() {


### PR DESCRIPTION
long options for the command line are removed. `getopt` is replaced with   
the newer `getopts` (which is compatible with Debian's `DASH` Shell)

* fixes https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/35

* adds sanity checks for user command line switches

* `update-ngxblocker` / `install-ngxblocker`:
            adds `-v` command line option to print blacklist version