### PR TITLE
update-ngxblocker: fix email regex

### DIFF
--- a/update-ngxblocker
+++ b/update-ngxblocker
@@ -174,7 +174,7 @@ check_args() {
 				exit 1
 			fi
 			;;
-	       email)   if ! echo $arg | grep -E ^[\.-_[:alnum:]]+@[\.-_[:alnum:]]+[\.][\.a-z]+ 1>/dev/null; then
+	       email)   if ! echo $arg | grep -E ^[-_\.[:alnum:]]+@[-_\.[:alnum:]]+ 1>/dev/null; then
 				printf "$msg email@domain.com\n"
 				exit 1
 			fi


### PR DESCRIPTION
* fixes regex for both busybox & GNU `grep`

closes https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/87