### PR TITLE
Remove Findxbot from the list

### DIFF
--- a/robots.txt/robots.txt
+++ b/robots.txt/robots.txt
@@ -259,8 +259,6 @@ User-agent: FHscan
 Disallow:/
 User-agent: Fimap
 Disallow:/
-User-agent: Findxbot
-Disallow:/
 User-agent: Firefox/7.0
 Disallow:/
 User-agent: FlashGet


### PR DESCRIPTION
Findxbot is the bot of the European search engine, https://www.findx.com. It's not harmfull, but crawls websites to build an independent, open source, search engine alternative. - more info on https://www.findxbot.com.

Feel free to get in touch for more information.