### PR TITLE
setup-ngxblocker: add option to configure all files

### DIFF
--- a/setup-ngxblocker
+++ b/setup-ngxblocker
@@ -79,9 +79,7 @@ update_paths() {
 }
 
 check_config() {
-	local files="$*"
-
-	if [ -z "$files" ]; then
+	if [ -z "$FILE_LIST" ]; then
 		printf "${BOLDGREEN}using a file extension for vhost files allows multiple domains to be included with a single directive in nginx.conf:\n\n"
 		printf "${BOLDWHITE}include /etc/nginx/sites-enabled/*.vhost;\n\n"
 		printf "${BOLDYELLOW}see command line switches below: ${BOLDGREEN}-e ${RESET}to customise the vhost file extension\n\n"
@@ -97,7 +95,16 @@ check_config() {
 }
 
 find_vhosts() {
-	find $VHOST_DIR -type f -name "*.$VHOST_EXT"
+	local ans=
+	FILE_LIST=$(find $VHOST_DIR -type f -name "*.$VHOST_EXT")
+
+	if [ -z "$FILE_LIST" ]; then
+		find $VHOST_DIR -type f
+		printf "\n${BOLDWHITE}Configure every file above as a vhost ? [Y/N] : "; read ans
+		case "$ans" in
+			y*|Y*) FILE_LIST=$(find $VHOST_DIR -type f);;
+		esac
+	fi
 }
 
 whitelist_ips() {
@@ -330,7 +337,7 @@ check_online() {
 }
 
 main() {
-	local include_url= file= line= file_list= col_size= blacklist=
+	local include_url= file= line= col_size= blacklist=
 	local CONF_FILES= VHOST_INCLUDES=
 	local REPO=https://raw.githubusercontent.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/master
 
@@ -345,8 +352,8 @@ main() {
 	check_depends
 
 	# check vhosts
-	file_list=$(find_vhosts)
-	check_config $file_list
+	find_vhosts
+	check_config
 
 	# check repo is online & source includes
 	include_url=$REPO/include_filelist.txt
@@ -394,7 +401,7 @@ main() {
 	fi
 
 	# update vhosts
-	for file in $file_list; do
+	for file in $FILE_LIST; do
 		line=$(find_includes $file include last server_ last location first )
 
 		if [ -n "$(check_wildcard $file $BOTS_DIR)" ]; then


### PR DESCRIPTION
* adds an option to `find_vhosts()` to configure all files in `$VHOST_DIR`
  if none are found with an extension of `$VHOST_EXT`

fixes https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/147
further fixes https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/137