### PR TITLE
do not sanitize + in email addresses

### DIFF
--- a/update-ngxblocker
+++ b/update-ngxblocker
@@ -174,8 +174,8 @@ sanitize_url() {
 }
 
 sanitize_email() {
-	echo $1 |tr -cd '[:alnum:] [=@=] [=.=] [=-=] [=_=]' \
-		|tr -s '@-_.' |awk '{print tolower($0)}'
+	echo $1 |tr -cd '[:alnum:] [=@=] [=.=] [=-=] [=_=] [=+=]' \
+		|tr -s '@-_.+' |awk '{print tolower($0)}'
 }
 
 check_args() {


### PR DESCRIPTION
* sanitizing `+` breaks google aliases

  fixes https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/157