### PR TITLE
Remove user agent false positive

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -137,7 +137,6 @@ Firefox/7.0
 FlashGet
 Flunky
 Foobot
-fq
 Freeuploader
 FrontPage
 Fyrebot


### PR DESCRIPTION
`fq` is a bit broad to match on a user agent perhaps?

It would match this genuine user agent (i presume the string is being used in a regex somewhere to do the matching? Unless the matching is case sensitive?)
```
Mozilla/5.0 (Linux; Android 5.0; SM-G900FQ Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
```