### PR TITLE
Remove wget dependency / emulate which

### DIFF
--- a/setup-ngxblocker
+++ b/setup-ngxblocker
@@ -285,12 +285,6 @@ check_args() {
 }
 
 check_depends() {
-	# centos does not have wget installed by default
-	if ! wget --help >/dev/null 2>&1; then
-		printf "${BOLDRED}ERROR${RESET}: $0 requires: 'wget' => ${BOLDWHITE}cannot download files.${RESET}\n"
-		exit 1
-	fi
-
 	# centos also does not have which by default
 	if [ ! -x /usr/bin/curl ]; then
 		printf "${BOLDRED}ERROR${RESET}: $0 requires: 'curl' => ${BOLDWHITE}cannot check remote version.${RESET}\n"
@@ -354,23 +348,11 @@ get_options() {
 	INSTALL_INC="$INSTALLER -b $BOTS_DIR -c $CONF_DIR -x"
 }
 
-wget_opts() {
-	local opts=
-
-	# GNU wget / Busybox 1.26.2
-	if wget --help 2>&1 | grep "\--spider" >/dev/null 2>&1; then
-		opts="--spider"
-	else    # Busybox wget < 1.26.2
-		opts="-s"
-	fi
-
-	echo $opts
-}
-
 check_online() {
-	local url=$1 options=$(wget_opts)
+	local url=$1
+	local response_code=$(curl -o /dev/null --silent --head --write-out '%{http_code}' $url)
 
-	if wget $options $url >/dev/null 2>&1; then
+	if [ "$response_code" = "200" ]; then
 		echo "true"
 	fi
 }
@@ -400,7 +382,7 @@ main() {
 	printf "Checking url: $include_url\n"
 	if [ -n "$(check_online $include_url)" ]; then
 		local tmp=$(mktemp)
-		wget -q $include_url -O $tmp
+		curl -s -o $tmp $include_url
 		# use period not source in POSIX shell
 		. $tmp 2>/dev/null
 		rm -f $tmp

--- a/setup-ngxblocker
+++ b/setup-ngxblocker
@@ -284,9 +284,22 @@ check_args() {
 	esac
 }
 
+find_binary() {
+        local x= path= bin=$1 bin_paths='/usr/bin /usr/local/bin /usr/sbin /usr/local/sbin /root/bin /root/.bin'
+
+        for x in $bin_paths; do
+                path="$x/$bin"
+
+                if [ -x $path ]; then
+                        echo $path
+                        return
+                fi
+        done
+}
+
 check_depends() {
-	# centos also does not have which by default
-	if [ ! -x /usr/bin/curl ]; then
+	# centos does not have which by default
+	if [ -z $(find_binary curl) ]; then
 		printf "${BOLDRED}ERROR${RESET}: $0 requires: 'curl' => ${BOLDWHITE}cannot check remote version.${RESET}\n"
 		exit 1
 	fi


### PR DESCRIPTION
* removes `wget` dependency
* adds `find_binary()` to emulate `which`

fixes https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/213