### PR TITLE
add find_binary()

### DIFF
--- a/update-ngxblocker
+++ b/update-ngxblocker
@@ -119,6 +119,19 @@ check_dirs() {
 	done
 }
 
+find_binary() {
+	local x= path= bin=$1 bin_paths='/usr/bin /usr/local/bin /usr/sbin /usr/local/sbin /root/bin /root/.bin'
+
+	for x in $bin_paths; do
+		path="$x/$bin"
+
+		if [ -x $path ]; then
+			echo $path
+			return
+		fi
+	done
+}
+
 update_paths() {
 	# variables in nginx include files not currently possible
 	# updates hard coded bots.d path in globalblacklist.conf


### PR DESCRIPTION
* emulates `which` as centos does not have it by default