### PR TITLE
fix DASH incompatibility

### DIFF
--- a/setup-ngxblocker
+++ b/setup-ngxblocker
@@ -154,7 +154,7 @@ whitelist_manual_domains() {
 }
 
 whitelist_print() {
-	local type=$1 domain= domain_len=$2 domain_list=$(echo $@ | cut -f3- -d ' ')
+	local type=$1 domain= domain_len=$2 domain_list="$(echo $@ | cut -f3- -d ' ')"
 	local conf=$BOTS_DIR/whitelist-domains.conf
 
         for domain in $domain_list; do


### PR DESCRIPTION
In Debian's `DASH` shell `local` variable lists need to be quoted when manipulated
positionally if the list contains a '`-`':

https://linux.die.net/man/1/dash

* fixes https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/224