### PR TITLE
fix fail2ban filter regex

### DIFF
--- a/_fail2ban_addon/filter.d/nginxrepeatoffender.conf
+++ b/_fail2ban_addon/filter.d/nginxrepeatoffender.conf
@@ -51,8 +51,8 @@ _daemon = fail2ban\.actions\s*
 # jail using this filter 'nginxrepeatoffender', or change this line!
 _jailname = nginxrepeatoffender
 
-failregex = ^<HOST> \- \S+ \[\] \"(GET|POST|HEAD) .* \S+\" (?:403|444) .+$
-ignoreregex = 
+failregex = ^<HOST> \- \S+ \[.*\] \"(GET|POST|HEAD) .* \S+\" (?:403|444) .+$
+ignoreregex = ^<HOST> \- \S+ \[.*\] \"(GET|POST|HEAD) .* \S+\" ?:200 .+$
 
 [Init]
 


### PR DESCRIPTION
* slightly less stringent regex that should work in most cases for  `403 / 444` http codes

* fixes https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/235