### PR TITLE
add pidof to required depends

### DIFF
--- a/install-ngxblocker
+++ b/install-ngxblocker
@@ -258,13 +258,20 @@ find_binary() {
 
 check_depends() {
 	# some distros do not have these tools installed by default
-	if [ -z $(find_binary wget) ]; then
-		printf "$0 requires: 'wget' \n"
-		exit 1
-	fi
+	local x= depends_list="wget curl"
 
-	if [ -z $(find_binary curl) ]; then
-		printf "$0 requires 'curl' \n"
+	for x in $depends_list; do
+		if [ -z $(find_binary $x) ]; then
+			printf "$0 requires: '$x' \n"
+			exit 1
+		fi
+	done
+
+	# give a helpful message for missing pidof
+	if [ -z $(find_binary pidof) ]; then
+		printf "$0 requires 'pidof' \n\n"
+		printf "In Debian: apt install sysvinit-utils\n"
+		printf "In Centos: yum install sysvinit-tools\n"
 		exit 1
 	fi
 }


### PR DESCRIPTION
Centos may not have `sysvinit-tools` installed by default. Adds a check for `pidof` being available.

Fixes:

https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/321#issuecomment-578514104