### PR TITLE
Add "Ankit" and "polaris version" to bad-user-agents.list

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -17,6 +17,7 @@ Alligator
 AllSubmitter
 AlphaBot
 Anarchie
+Ankit
 Apexoo
 archive.org_bot
 arquivo.pt
@@ -348,6 +349,7 @@ PleaseCrawl
 plumanalytics
 Pockey
 POE-Component-Client-HTTP
+polaris\ version
 Probethenet
 ProPowerBot
 ProWebWalker


### PR DESCRIPTION
Adding these  bad user agents trying to perform repeated attacks:

Ankit:
```
92.55.25.70 - - [25/Feb/2020:15:20:15 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "Ankit"
119.165.235.240 - - [26/Feb/2020:00:04:00 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "Ankit"
119.165.235.240 - - [26/Feb/2020:00:04:06 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "Ankit"
119.165.235.240 - - [26/Feb/2020:00:04:34 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "Ankit"
117.196.237.239 - - [26/Feb/2020:00:11:20 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "Ankit"
50.115.168.184 - - [26/Feb/2020:04:39:54 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "Ankit"
50.115.168.184 - - [26/Feb/2020:04:40:58 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "Ankit"
128.72.168.45 - - [26/Feb/2020:07:30:00 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "Ankit"
```

polaris version /1.0 (zyxel scanner)
```
164.132.12.24 - - [25/Feb/2020:23:14:49 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "polaris version /1.0 (zyxel scanner)"
83.213.102.93 - - [25/Feb/2020:23:27:51 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "polaris version /1.0 (zyxel scanner)"
164.132.12.24 - - [25/Feb/2020:23:38:20 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "polaris version /1.0 (zyxel scanner)"
164.132.92.147 - - [26/Feb/2020:03:22:50 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "polaris version /1.0 (zyxel scanner)"
164.132.92.147 - - [26/Feb/2020:06:49:45 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "polaris version /1.0 (zyxel scanner)"
164.132.92.147 - - [26/Feb/2020:11:00:51 +0000] "POST /cgi-bin/ViewLog.asp HTTP/1.1" 404 152 "-" "polaris version /1.0 (zyxel scanner)"
```