### PR TITLE
Fix bot name from Aspeigel to Aspiegel

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -22,7 +22,7 @@ Apexoo
 archive.org_bot
 arquivo.pt
 arquivo-web-crawler
-Aspeigel
+Aspiegel
 ASPSeek
 Asterias
 Attach


### PR DESCRIPTION
I think we were wrong about this bot name `Aspeigel`. 
The correct name should be `Aspiegel`.

My access log:
```
114.119.160.17 - - [31/Mar/2020:07:45:46 +0700] "GET /my_website_path HTTP/1.1" 200 22605 "-" "Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)" "-"
```