### PR TITLE
add /sbin to binary search paths

### DIFF
--- a/install-ngxblocker
+++ b/install-ngxblocker
@@ -245,7 +245,7 @@ wget_opts() {
 }
 
 find_binary() {
-        local x= path= binary=$1 bin_paths='/bin /usr/bin /usr/local/bin /usr/sbin /usr/local/sbin /root/bin /root/.bin'
+        local x= path= binary=$1 bin_paths='/bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /root/bin /root/.bin'
 
         for x in $bin_paths; do
                 path="$x/$binary"

--- a/setup-ngxblocker
+++ b/setup-ngxblocker
@@ -292,7 +292,7 @@ check_args() {
 }
 
 find_binary() {
-        local x= path= binary=$1 bin_paths='/bin /usr/bin /usr/local/bin /usr/sbin /usr/local/sbin /root/bin /root/.bin'
+        local x= path= binary=$1 bin_paths='/bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /root/bin /root/.bin'
 
         for x in $bin_paths; do
                 path="$x/$binary"

--- a/update-ngxblocker
+++ b/update-ngxblocker
@@ -132,7 +132,7 @@ check_dirs() {
 }
 
 find_binary() {
-	local x= path= binary=$1 bin_paths='/bin /usr/bin /usr/local/bin /usr/sbin /usr/local/sbin /root/bin /root/.bin'
+	local x= path= binary=$1 bin_paths='/bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /root/bin /root/.bin'
 
 	for x in $bin_paths; do
 		path="$x/$binary"


### PR DESCRIPTION
* Amazon Linux puts `pidof` under `/sbin`

  fixes https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/issues/399