### PR TITLE
add lower case masscan user agent

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -274,6 +274,7 @@ Majestic\ SEO
 MarkMonitor
 MarkWatch
 Masscan
+masscan
 Mass\ Downloader
 Mata\ Hari
 MauiBot


### PR DESCRIPTION
Hello,

A user reported that masscan uses a lower case user-agent.
Can we add a lower-case version of masscan user agent?

Thanks,
