### PR TITLE
Update bad-user-agents.list

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -643,3 +643,5 @@ x22Mozilla
 xpymep1.exe
 zauba.io
 zgrab
+Rainbot
+TinyTestBot


### PR DESCRIPTION
Added Rainbot and TinyTestBot user agents

Couldn't find any relevant info about them (who's operating them, what's their purpose, etc.) but both have generated a significant number of requests. Rainbot was so intense it was pretty much a DOS (they used 3 IPs).