### PR TITLE
Update update-ngxblocker - added check_depends to check_version

### DIFF
--- a/update-ngxblocker
+++ b/update-ngxblocker
@@ -91,6 +91,8 @@ check_version() {
 	local remote_ver= remote_date= version= date= file=$CONF_DIR/globalblacklist.conf
 	local tmp=$(mktemp) url=$REPO/conf.d/globalblacklist.conf range="145-345"
 
+	check_depends
+
 	if [ -f $file ]; then
 		# local version
 		version=$(grep "Version:" $file | ${SED_CMD} 's|^.*: V||g')


### PR DESCRIPTION
update-ngxblocker -v didn't work as check_version was called without 'check_depends' and didn't get all binaries / paths.