### PR TITLE
fix(update-ngxblocker): use correct unix mail return address flag

### DIFF
--- a/update-ngxblocker
+++ b/update-ngxblocker
@@ -272,7 +272,7 @@ send_email() {
 		${SED_CMD} -i 's/\x1b\[[0-9;]*m//g' $EMAIL_REPORT
 
 		if [ -n "$MG_FROM" ]; then
-			cat $EMAIL_REPORT | $mail_path -f "$MG_FROM" -s "Nginx Bad Bot Blocker Updated" $EMAIL
+			cat $EMAIL_REPORT | $mail_path -r "$MG_FROM" -s "Nginx Bad Bot Blocker Updated" $EMAIL
 		else
 			cat $EMAIL_REPORT | $mail_path -s "Nginx Bad Bot Blocker Updated" $EMAIL
 		fi


### PR DESCRIPTION
`update-ngxblocker` uses -f to specify the return address. GNU `mail.mailutils` uses -r to specify the return address.

previously, `update-ngxblocker` would report:
```
Emailing report to: <snip>

mail: conflicting options
```

The second line is gone with this change, and `/var/log/mail.log` reports (250 Ok).