### PR TITLE
Extend Semrush user-agents

### DIFF
--- a/robots.txt/robots.txt
+++ b/robots.txt/robots.txt
@@ -861,6 +861,20 @@ User-agent: Semrush
 Disallow:/
 User-agent: SemrushBot
 Disallow:/
+User-agent: SiteAuditBot
+Disallow:/
+User-agent: SemrushBot-BA
+Disallow:/
+User-agent: SemrushBot-SI
+Disallow:/
+User-agent: SemrushBot-SWA
+Disallow:/
+User-agent: SplitSignalBot
+Disallow:/
+User-agent: SemrushBot-OCOB
+Disallow:/
+User-agent: SemrushBot-FT
+Disallow:/
 User-agent: SentiBot
 Disallow:/
 User-agent: SenutoBot


### PR DESCRIPTION
Extending the Semrush bot user agents string, documented at: https://www.semrush.com/bot/


> To block SemrushBot from crawling your site for different SEO and technical issues:
> 
>     User-agent: SiteAuditBot
>     Disallow: / 
> 
> To block SemrushBot from crawling your site for Backlink Audit tool:
> 
>     User-agent: SemrushBot-BA
>     Disallow: / 
> 
> To block SemrushBot from crawling your site for On Page SEO Checker tool and similar tools:
> 
>     User-agent: SemrushBot-SI
>     Disallow: / 
> 
> To block SemrushBot from checking URLs on your site for SWA tool:
> 
>     User-agent: SemrushBot-SWA
>     Disallow: / 
> 
> To block SplitSignalBot from crawling your site for SplitSignal tool:
> 
>     User-agent: SplitSignalBot
>     Disallow: / 
> 
> To block SemrushBot-OCOB from crawling your site for ContentShake AI tool:
> 
>     User-agent: SemrushBot-OCOB
>     Disallow: / 
> 
> To block SemrushBot-FT from crawling your site for Plagiarism Checker and similar tools:
> 
>     User-agent: SemrushBot-FT
>     Disallow: / 

Thank you!