### PR TITLE
Add additional bad AI user agents to the list

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -88,11 +88,15 @@ ChinaClaw
 Chlooe
 Citoid
 Claritybot
+Claude-SearchBot
+Claude-User
 ClaudeBot
+Cloudflare-AutoRAG
 Cliqzbot
 Cloud\ mapping
 Cocolyzebot
 Cogentbot
+cohere-training-data-crawler
 Collector
 Copier
 CopyRightCheck


### PR DESCRIPTION
- Added new AI user agents to the bad user agents list. 
- Since `ChatGPT-User` was already in the list, I added `Claude` AI user agents as well.  Especially `Claude-SearchBot` can be very annoying trying to index your whole site.
- Same as Claude Searchbot can be said about `Cloudflare-AutoRAG` and `cohere-training-data-crawler`

If you want me to add more or remove some of my AI user-agents, let me know, I will update this PR.

There are more AI user-agents you may or may not want to add, eg. see also this list: https://github.com/ai-robots-txt/ai.robots.txt/blob/443dd275277bb42c2dc0d243d28d53c87f20e22f/robots.txt