### PR TITLE
User agent order

### DIFF
--- a/conf.d/globalblacklist.conf
+++ b/conf.d/globalblacklist.conf
@@ -194,6 +194,7 @@ map $http_user_agent $bad_bot {
 	"~*(?:\b)slurp(?:\b)"		0;
 	"~*(?:\b)teoma(?:\b)"		0;
 	"~*(?:\b)yahoo(?:\b)"		0;
+	"~*(?:\b)Revolut-Octopus(?:\b)"		0;
 # END GOOD BOTS ### DO NOT EDIT THIS LINE AT ALL ###
 
 # --------------------------------------------------------


### PR DESCRIPTION
Hi,

We ran into an issue with the User-Agent rules order. 

The block rule on _Octopus_ User-Agent is matched before [L491](https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/blob/master/conf.d/globalblacklist.conf#L491) any good User-Agents can match [L848](https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/blob/master/conf.d/globalblacklist.conf#L848). Considering that the bad User-Agents are matched before the Good ones, I propose that we move the bad User-Agents after the good and rate limited ones.

In the process, I also added Revolut-Octopus as a good User-Agent.