### PR TITLE
Add 2 meta user-agents to bad user agents list

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -294,6 +294,7 @@ Meanpathbot
 Mediatoolkitbot
 MegaIndex.ru
 Metauri
+meta-externalagent
 MicroMessenger
 Microsoft\ Data\ Access
 Microsoft\ URL\ Control

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -295,6 +295,7 @@ Mediatoolkitbot
 MegaIndex.ru
 Metauri
 meta-externalagent
+meta-webindexer
 MicroMessenger
 Microsoft\ Data\ Access
 Microsoft\ URL\ Control


### PR DESCRIPTION
- Adding `meta-externalagent` to the bad user list, see also: https://developers.facebook.com/docs/sharing/webmasters/web-crawlers
- Also add `meta-webindexer`: "The Meta-WebIndexer crawler navigates the web to improve Meta AI search result quality for users. In doing so, Meta analyzes online content to enhance the relevance and accuracy of Meta AI."
- Despite this name, its an AI crawler bot: "supports product functions such as evaluating and improving agentic AI capabilities—including helping AI navigate websites to complete tasks for users."


Meta AI crawler bot is relentless  and is hamming my domain since 19:00PM yesterday (300-400 requests per min. for hours):

<img width="1877" height="623" alt="image" src="https://github.com/user-attachments/assets/2f633026-3ca3-48f1-9c12-2058dbbc45e7" />

<img width="766" height="496" alt="image" src="https://github.com/user-attachments/assets/c6cd806f-cb79-4485-b0d8-78ad6f736a07" />

