### PR TITLE
Fix dead link to the .htaccess versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ Lots of people are at the peril of their hosting company and do not have root ac
 
 Lots of people are at the peril of their hosting company and do not have root access to the server running behind their web site. 
 
-If this is your situation check out the automatically generated .htaccess versions of the Spam Referrer Blocker which can be found in <a href="https://github.com/mitchellkrogza/apache-ultimate-bad-bot-blocker/tree/master/.htaccess">this repository</a> this .htaccess method (FOR APACHE SITES ONLY) will help you to keep all the Spam Referrers in this blocker out of your site. 
+If this is your situation check out the automatically generated .htaccess versions of the Spam Referrer Blocker which can be found in <a href="https://github.com/mitchellkrogza/apache-ultimate-bad-bot-blocker/tree/master/_htaccess_versions">this repository</a> this .htaccess method (FOR APACHE SITES ONLY) will help you to keep all the Spam Referrers in this blocker out of your site. 
 
 This is merely mentioned here as a lot of people using CPanel systems think they are sitting behind an Nginx server but in reality are actually running on an Apache Server sitting behind an Nginx Proxy Server. .htaccess does not work on Nginx sites.
 


### PR DESCRIPTION
The README (Spam Referrer Blocker section) links to `apache-ultimate-bad-bot-blocker/tree/master/.htaccess`, which returns HTTP 404 — there is no `.htaccess` path in that repository's root.

The automatically generated .htaccess versions live under [`_htaccess_versions/`](https://github.com/mitchellkrogza/apache-ultimate-bad-bot-blocker/tree/master/_htaccess_versions) (`htaccess-mod_rewrite.txt`, `htaccess-mod_setenvif.txt`), which matches the sentence "check out the automatically generated .htaccess versions". This PR updates the link accordingly.

No other changes.